### PR TITLE
higher priority for template_include hook

### DIFF
--- a/includes/class-mailtpl.php
+++ b/includes/class-mailtpl.php
@@ -187,7 +187,7 @@ class Mailtpl {
 			$this->loader->add_action( 'customize_register', $this->customizer, 'register_customize_sections' );
 			$this->loader->add_action( 'customize_section_active', $this->customizer, 'remove_other_sections', 10, 2 );
 			$this->loader->add_action( 'customize_panel_active', $this->customizer, 'remove_other_panels', 10, 2 );
-			$this->loader->add_action( 'template_include', $this->customizer, 'capture_customizer_page' );
+			$this->loader->add_action( 'template_include', $this->customizer, 'capture_customizer_page', 999 );
 		}
 
 		$this->loader->add_filter( 'wp_mail', $this->mailer, 'send_email' );


### PR DESCRIPTION
if a theme defines explicit woocommerce support via add_theme_support( 'woocommerce' );
then woocommerce itself uses this hook to load the template (in "woocommerce\includes\class-wc-template-loader.php") so we need a higher priority to override it